### PR TITLE
feat: improve typing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,20 @@
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Protocol
 from unittest.mock import Mock
 
 import pytest
 
-from cleanstack.domain import BaseDomain, CommandHandler, ContextProtocol
+from cleanstack.domain import BaseContextProtocol, BaseDomain, CommandHandler
+
+
+class ContextProtocol(BaseContextProtocol, Protocol): ...
+
+
+class MockContext(ContextProtocol):
+    transaction: Mock
+    commit: Mock
+    rollback: Mock
 
 
 def successful_command(context: ContextProtocol, x: str) -> str:
@@ -15,13 +25,7 @@ def failed_command(context: ContextProtocol) -> str:
     raise ValueError("command failed")
 
 
-class MockContext(ContextProtocol):
-    transaction: Mock
-    commit: Mock
-    rollback: Mock
-
-
-class DomainTest(BaseDomain):
+class DomainTest(BaseDomain[ContextProtocol]):
     successful_command = CommandHandler(successful_command)
     failed_command = CommandHandler(failed_command)
 


### PR DESCRIPTION
## Summary by Sourcery

Improve static typing in the domain layer by introducing a context type variable, renaming and refactoring the context protocol, and updating tests to match the new typing model

Enhancements:
- Parameterize BaseDomain and CommandHandler with a context type variable for stronger typing
- Rename ContextProtocol to BaseContextProtocol and update the protocol definition for clarity
- Use typing.Protocol to define the test-specific ContextProtocol and adjust imports accordingly

Tests:
- Update conftest to define and use the new Protocol-based ContextProtocol and adapt DomainTest to the generic BaseDomain