### PR TITLE
chore: update release-please token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           release-type: python
-          skip-labeling: false


### PR DESCRIPTION
## Summary by Sourcery

Update the release-please GitHub Actions workflow to use a dedicated token and simplify configuration

CI:
- Use RELEASE_PLEASE_TOKEN instead of GITHUB_TOKEN in the release-please action
- Remove skip-labeling configuration from the release-please workflow