### PR TITLE
chore: update release-please action to exclude 'v' in tags

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           release-type: python
+          include-v-in-tag: false


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Disable v prefix in release tags by setting include-v-in-tag to false