### PR TITLE
fix: release-please config

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,0 +1,8 @@
+{
+  "packages": {
+    ".": {
+      "release-type": "python",
+      "include-v-in-tag": false
+    }
+  }
+}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,5 +16,4 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          release-type: python
-          include-v-in-tag: false
+          config-file: .github/release-please-config.json


### PR DESCRIPTION
## Summary by Sourcery

Use an external configuration file for the release-please GitHub Action instead of inline settings

Enhancements:
- Move release-please settings (release type and tag format) into .github/release-please-config.json

CI:
- Update release-please workflow to reference the new config file instead of inline parameters

Chores:
- Add .github/release-please-config.json file