### PR TITLE
feat: add domain exceptions

### DIFF
--- a/cleanstack/exceptions.py
+++ b/cleanstack/exceptions.py
@@ -2,9 +2,21 @@ class DomainError(Exception):
     pass
 
 
+class BadRequestError(DomainError):
+    pass
+
+
+class ForbiddenError(DomainError):
+    pass
+
+
 class NotFoundError(DomainError):
     pass
 
 
-class AlreadyExistsError(DomainError):
+class ConflictError(DomainError):
+    pass
+
+
+class UnprocessableEntityError(DomainError):
     pass

--- a/cleanstack/fastapi/exceptions.py
+++ b/cleanstack/fastapi/exceptions.py
@@ -10,14 +10,24 @@ except ImportError as e:
         'To use FastAPI utilities, you need to install "cleanstack[fastapi]"'
     ) from e
 
-from cleanstack.exceptions import AlreadyExistsError, DomainError, NotFoundError
+from cleanstack.exceptions import (
+    BadRequestError,
+    ConflictError,
+    DomainError,
+    ForbiddenError,
+    NotFoundError,
+    UnprocessableEntityError,
+)
 from cleanstack.logger import logger
 
 
 class ExceptionRegistry:
     _exc_mapping: ClassVar[dict[type[Exception], int]] = {
+        BadRequestError: status.HTTP_400_BAD_REQUEST,
+        ForbiddenError: status.HTTP_403_FORBIDDEN,
         NotFoundError: status.HTTP_404_NOT_FOUND,
-        AlreadyExistsError: status.HTTP_409_CONFLICT,
+        ConflictError: status.HTTP_409_CONFLICT,
+        UnprocessableEntityError: status.HTTP_422_UNPROCESSABLE_ENTITY,
     }
 
     @classmethod

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "cleanstack"
-version = "0.3.0"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary by Sourcery

Introduce new domain exception classes and integrate them into FastAPI exception handling with appropriate HTTP status codes

New Features:
- Add BadRequestError and ForbiddenError domain exceptions

Enhancements:
- Rename AlreadyExistsError to ConflictError
- Update FastAPI ExceptionRegistry to map BadRequestError (400), ForbiddenError (403), ConflictError (409), and UnprocessableEntityError (422) to HTTP status codes

Chores:
- Regenerate lock file